### PR TITLE
Add predictions_open tournament setting to keep tournament/stage/group manually open after kick-off #31 #patch

### DIFF
--- a/backend/src/predictions/crud.py
+++ b/backend/src/predictions/crud.py
@@ -11,7 +11,7 @@ from src.predictions import models
 from src.matches.models import Match
 from src.groups_stages.models import Group, Stage
 from src.teams.models import Team
-from src.tournaments.models import TournamentAdminLink
+from src.tournaments.models import TournamentAdminLink, Tournament
 from src.predictions import scoring as predictions_scoring
 
 
@@ -58,6 +58,15 @@ async def get_stage_start_datetime(db: AsyncSession, stage_id: int) -> Optional[
         select(sa.func.min(Match.start_datetime)).where(Match.stage_id == stage_id)
     )
     return result.scalar_one_or_none()
+
+
+async def get_tournament_predictions_open(db: AsyncSession, tournament_id: int) -> str:
+    """Return the predictions_open setting ('automatic', 'open', or 'closed') for a tournament."""
+    result = await db.execute(
+        select(Tournament.predictions_open).where(Tournament.id == tournament_id)
+    )
+    value = result.scalar_one_or_none()
+    return value if value is not None else "automatic"
 
 
 

--- a/backend/src/predictions/routers.py
+++ b/backend/src/predictions/routers.py
@@ -74,9 +74,15 @@ async def upsert_predict_tournament_endpoint(
     if await crud.is_admin_of_tournament(db, data.tournament_id, token_user_id) and target_user_id != token_user_id:
         pass  # admin editing another user's prediction
     elif target_user_id == token_user_id:
-        start_dt = await crud.get_tournament_start_datetime(db, data.tournament_id)
-        if start_dt is None or start_dt.astimezone(timezone.utc) <= datetime.now(timezone.utc):
-            raise CustomError("Forbidden: predictions can only be submitted before the tournament starts", status_code=403)
+        predictions_open = await crud.get_tournament_predictions_open(db, data.tournament_id)
+        if predictions_open == "closed":
+            raise CustomError("Forbidden: predictions are closed for this tournament", status_code=403)
+        elif predictions_open == "open":
+            pass  # always allowed
+        else:  # automatic
+            start_dt = await crud.get_tournament_start_datetime(db, data.tournament_id)
+            if start_dt is None or start_dt.astimezone(timezone.utc) <= datetime.now(timezone.utc):
+                raise CustomError("Forbidden: predictions can only be submitted before the tournament starts", status_code=403)
     else:
         raise CustomError("Forbidden: predictions can only be submitted before the tournament starts or by admins", status_code=403)
     return await crud.upsert_predict_tournament(db, data, target_user_id)
@@ -138,9 +144,15 @@ async def upsert_predict_group_endpoint(
     if await crud.is_admin_of_tournament(db, group.tournament_id, token_user_id) and target_user_id != token_user_id:
         pass  # admin editing another user's prediction
     elif target_user_id == token_user_id:
-        start_dt = await crud.get_group_start_datetime(db, data.group_id)
-        if start_dt is None or start_dt.astimezone(timezone.utc) <= datetime.now(timezone.utc):
-            raise CustomError("Forbidden: predictions can only be submitted before the group starts", status_code=403)
+        predictions_open = await crud.get_tournament_predictions_open(db, group.tournament_id)
+        if predictions_open == "closed":
+            raise CustomError("Forbidden: predictions are closed for this tournament", status_code=403)
+        elif predictions_open == "open":
+            pass  # always allowed
+        else:  # automatic
+            start_dt = await crud.get_group_start_datetime(db, data.group_id)
+            if start_dt is None or start_dt.astimezone(timezone.utc) <= datetime.now(timezone.utc):
+                raise CustomError("Forbidden: predictions can only be submitted before the group starts", status_code=403)
     else:
         raise CustomError("Forbidden: predictions can only be submitted before the group starts or by admins", status_code=403)
     return await crud.upsert_predict_group(db, data, target_user_id, background_tasks)
@@ -228,9 +240,15 @@ async def upsert_predict_stage_endpoint(
     if await crud.is_admin_of_tournament(db, stage.tournament_id, token_user_id) and target_user_id != token_user_id:
         pass  # admin editing another user's prediction
     elif target_user_id == token_user_id:
-        start_dt = await crud.get_stage_start_datetime(db, data.stage_id)
-        if start_dt is None or start_dt.astimezone(timezone.utc) <= datetime.now(timezone.utc):
-            raise CustomError("Forbidden: predictions can only be submitted before the stage starts", status_code=403)
+        predictions_open = await crud.get_tournament_predictions_open(db, stage.tournament_id)
+        if predictions_open == "closed":
+            raise CustomError("Forbidden: predictions are closed for this tournament", status_code=403)
+        elif predictions_open == "open":
+            pass  # always allowed
+        else:  # automatic
+            start_dt = await crud.get_stage_start_datetime(db, data.stage_id)
+            if start_dt is None or start_dt.astimezone(timezone.utc) <= datetime.now(timezone.utc):
+                raise CustomError("Forbidden: predictions can only be submitted before the stage starts", status_code=403)
     else:
         raise CustomError("Forbidden: predictions can only be submitted before the stage starts or by admins", status_code=403)
     return await crud.upsert_predict_stage(db, data, target_user_id, background_tasks)

--- a/backend/src/tournaments/models.py
+++ b/backend/src/tournaments/models.py
@@ -46,6 +46,12 @@ class TournamentParticipantLink(SQLModel, table=True):
 # Base / DB model
 # ---------------------------------------------------------------------------
 
+class PredictionsOpen(str, Enum):
+    automatic = "automatic"
+    open = "open"
+    closed = "closed"
+
+
 class TournamentBase(SQLModel):
     """Shared tournament fields used across create, read, and update schemas."""
     name: str = Field(..., min_length=1, max_length=255)
@@ -61,6 +67,7 @@ class TournamentBase(SQLModel):
     match_score_points: Optional[int] = Field(default=5, ge=0)
     group_winner_points: Optional[int] = Field(default=8, ge=0)
     stage_winner_points: Optional[int] = Field(default=0, ge=0)
+    predictions_open: PredictionsOpen = Field(default=PredictionsOpen.automatic)
 
 
 class Tournament(TournamentBase, table=True):
@@ -69,6 +76,10 @@ class Tournament(TournamentBase, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     join_code: Optional[str] = Field(default=None, unique=True, max_length=16)
     stake: Optional[str] = Field(default=None, sa_column=sa.Column(sa.Text, nullable=True))
+    predictions_open: PredictionsOpen = Field(
+        default=PredictionsOpen.automatic,
+        sa_column=sa.Column(sa.String(16), nullable=False, default="automatic", server_default="automatic"),
+    )
     football_data_org_id: Optional[int] = Field(default=None, unique=False)
     first_place_team_id: Optional[int] = Field(default=None, sa_column=sa.Column(sa.Integer, sa.ForeignKey("team.id", use_alter=True, name="fk_tournament_first_place_team_id"), nullable=True))
     second_place_team_id: Optional[int] = Field(default=None, sa_column=sa.Column(sa.Integer, sa.ForeignKey("team.id", use_alter=True, name="fk_tournament_second_place_team_id"), nullable=True))

--- a/frontend/src/modals/tournament.tsx
+++ b/frontend/src/modals/tournament.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { BellRing, CircleDollarSign, Crown, Loader2, RefreshCw, UserX } from 'lucide-react'
+import { BellRing, CircleDollarSign, Crown, HelpCircle, Loader2, RefreshCw, UserX } from 'lucide-react'
 import {
   useCreateTournamentMutation,
   useUpdateTournamentMutation,
@@ -10,7 +10,7 @@ import {
   useSendAdminActionMutation,
 } from '../api/tournamentApi'
 import { useGetParticipantActivityQuery } from '../api/statsApi'
-import type { TournamentAdminAction } from '../types'
+import type { PredictionsOpen, TournamentAdminAction } from '../types'
 import { useListFootballDataOrgTournamentsQuery } from '../api/footballDataOrgApi'
 import { useListTeamsQuery } from '../api/teamApi'
 import { useGetMeQuery } from '../api/authApi'
@@ -187,6 +187,8 @@ function TournamentInfoFields({
   setStake,
   footballDataOrgId,
   setFootballDataOrgId,
+  predictionsOpen,
+  setPredictionsOpen,
   autoFocusName,
   disabled,
 }: {
@@ -196,6 +198,8 @@ function TournamentInfoFields({
   setStake: (v: string) => void
   footballDataOrgId: string
   setFootballDataOrgId: (v: string) => void
+  predictionsOpen: PredictionsOpen
+  setPredictionsOpen: (v: PredictionsOpen) => void
   autoFocusName?: boolean
   disabled?: boolean
 }) {
@@ -246,6 +250,32 @@ function TournamentInfoFields({
           </select>
         )}
       </div>
+      <div>
+        <FieldLabel>
+          Predictions Open{' '}
+          <span className="relative inline-flex items-center group/tip cursor-help">
+            <HelpCircle size={13} className="text-gray-400 dark:text-gray-500" />
+            <span className="pointer-events-none absolute bottom-full left-0 mb-2 w-72 rounded-lg bg-gray-800 dark:bg-gray-900 text-white text-xs font-normal px-3 py-2 shadow-lg opacity-0 group-hover/tip:opacity-100 transition-opacity z-50 normal-case tracking-normal leading-relaxed">
+              With <strong>Automatic</strong>, tournament, group, and stage predictions are automatically closed on the day of their respective first match.
+              {' '}<strong>Open</strong> keeps those predictions open regardless of schedule.
+              {' '}<strong>Closed</strong> prevents users from submitting tournament, group, and stage predictions.
+              {' '}Match predictions are always controlled by the individual match kick-off time.
+              {' '}Admins can always update other users' predictions.
+              <span className="absolute top-full left-3 border-4 border-transparent border-t-gray-800 dark:border-t-gray-900" />
+            </span>
+          </span>
+        </FieldLabel>
+        <select
+          value={predictionsOpen}
+          onChange={(e) => setPredictionsOpen(e.target.value as PredictionsOpen)}
+          disabled={disabled}
+          className={fieldClass}
+        >
+          <option value="automatic">Automatic</option>
+          <option value="open">Open</option>
+          <option value="closed">Closed</option>
+        </select>
+      </div>
     </>
   )
 }
@@ -268,6 +298,7 @@ export function CreateTournamentModal({ onClose }: { onClose: () => void }) {
   const [matchScorePoints, setMatchScorePoints] = useState('5')
   const [groupWinnerPoints, setGroupWinnerPoints] = useState('8')
   const [stageWinnerPoints, setStageWinnerPoints] = useState('')
+  const [predictionsOpen, setPredictionsOpen] = useState<PredictionsOpen>('automatic')
   const [error, setError] = useState<string | null>(null)
 
   async function handleCreate() {
@@ -285,6 +316,7 @@ export function CreateTournamentModal({ onClose }: { onClose: () => void }) {
         match_score_points: matchScorePoints !== '' ? Number(matchScorePoints) : undefined,
         group_winner_points: groupWinnerPoints !== '' ? Number(groupWinnerPoints) : undefined,
         stage_winner_points: stageWinnerPoints !== '' ? Number(stageWinnerPoints) : undefined,
+        predictions_open: predictionsOpen,
       }).unwrap()
       onClose()
       navigate(`/tournament/${tournament.id}?guide=admin`)
@@ -303,6 +335,8 @@ export function CreateTournamentModal({ onClose }: { onClose: () => void }) {
           setStake={setStake}
           footballDataOrgId={footballDataOrgId}
           setFootballDataOrgId={setFootballDataOrgId}
+          predictionsOpen={predictionsOpen}
+          setPredictionsOpen={setPredictionsOpen}
           autoFocusName
           disabled={isLoading}
         />
@@ -410,6 +444,9 @@ export function EditTournamentModal({
   )
   const [thirdPlaceTeamId, setThirdPlaceTeamId] = useState(
     tournament.third_place_team_id?.toString() ?? '',
+  )
+  const [predictionsOpen, setPredictionsOpen] = useState<PredictionsOpen>(
+    tournament.predictions_open ?? 'automatic',
   )
   const [error, setError] = useState<string | null>(null)
   const [memberError, setMemberError] = useState<string | null>(null)
@@ -526,6 +563,7 @@ export function EditTournamentModal({
           match_score_points: matchScorePoints !== '' ? Number(matchScorePoints) : undefined,
           group_winner_points: groupWinnerPoints !== '' ? Number(groupWinnerPoints) : undefined,
           stage_winner_points: stageWinnerPoints !== '' ? Number(stageWinnerPoints) : undefined,
+          predictions_open: predictionsOpen,
         },
       }).unwrap()
       onClose()
@@ -544,6 +582,8 @@ export function EditTournamentModal({
           setStake={setStake}
           footballDataOrgId={footballDataOrgId}
           setFootballDataOrgId={setFootballDataOrgId}
+          predictionsOpen={predictionsOpen}
+          setPredictionsOpen={setPredictionsOpen}
           disabled={isLoading}
         />
         <EditPointAndTeamFields

--- a/frontend/src/pages/PredictionsPage.tsx
+++ b/frontend/src/pages/PredictionsPage.tsx
@@ -534,10 +534,17 @@ export function PredictionsPage() {
     ? stages.filter((s) => s.start_date != null && s.start_date <= today)
     : stages)
 
-  // For admin editing another user, override disabled so all inputs are editable
+  // For admin editing another user, override disabled so all inputs are editable.
+  // For own predictions, respect predictions_open: 'open' forces enabled, 'closed' forces disabled,
+  // 'automatic' falls back to the date-based check.
+  const predictionsOpen = tournament.predictions_open ?? 'automatic'
   const tournamentDisabled = adminEditingOther
     ? false
-    : (tournament.start_date != null && tournament.start_date <= today)
+    : predictionsOpen === 'open'
+      ? false
+      : predictionsOpen === 'closed'
+        ? true
+        : (tournament.start_date != null && tournament.start_date <= today)
 
   return (
     <PageShell>
@@ -630,7 +637,13 @@ export function PredictionsPage() {
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
               {visibleStages.map((stage) => {
                 const stageStarted = stage.start_date != null ? stage.start_date <= today : false
-                const stageDisabled = adminEditingOther ? false : stageStarted
+                const stageDisabled = adminEditingOther
+                  ? false
+                  : predictionsOpen === 'open'
+                    ? false
+                    : predictionsOpen === 'closed'
+                      ? true
+                      : stageStarted
                 return (
                   <TeamSelect
                     key={stage.id}
@@ -667,7 +680,13 @@ export function PredictionsPage() {
               {visibleGroups.map((group) => {
                 const groupTeams = teams.filter((t) => t.group_id === group.id)
                 const groupStarted = group.start_date != null ? group.start_date <= today : false
-                const groupDisabled = adminEditingOther ? false : groupStarted
+                const groupDisabled = adminEditingOther
+                  ? false
+                  : predictionsOpen === 'open'
+                    ? false
+                    : predictionsOpen === 'closed'
+                      ? true
+                      : groupStarted
                 return (
                   <TeamSelect
                     key={group.id}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,6 @@
 // Re-export all domain types from a single entry point
 export type { Gender, User, UserUpdate, LoginRequest, RegisterRequest, ChangePasswordRequest, ForgotPasswordRequest, ResetPasswordRequest } from './auth'
-export type { Tournament, TournamentUser, TournamentCreate, TournamentUpdate, TournamentMemberUpdate, TournamentStakePaidUpdate, FootballDataOrgTournament, TournamentAdminAction, TournamentAdminActionRequest } from './tournament'
+export type { Tournament, TournamentUser, TournamentCreate, TournamentUpdate, TournamentMemberUpdate, TournamentStakePaidUpdate, FootballDataOrgTournament, TournamentAdminAction, TournamentAdminActionRequest, PredictionsOpen } from './tournament'
 export type { Team, TeamCreate, TeamUpdate } from './team'
 export type { Group, GroupCreate, GroupUpdate, Stage, StageCreate, StageUpdate } from './group'
 export type { Match, MatchCreate, MatchUpdate } from './match'

--- a/frontend/src/types/tournament.ts
+++ b/frontend/src/types/tournament.ts
@@ -1,5 +1,7 @@
 import type { TeamRead } from './team'
 
+export type PredictionsOpen = 'automatic' | 'open' | 'closed'
+
 export interface FootballDataOrgTournament {
   id: number
   name: string
@@ -32,6 +34,7 @@ export interface Tournament {
   match_score_points: number | null
   group_winner_points: number | null
   stage_winner_points: number | null
+  predictions_open: PredictionsOpen
   admin_lst: TournamentUser[]
   participant_lst: TournamentUser[]
   start_date: string | null
@@ -55,6 +58,7 @@ export interface TournamentCreate {
   match_score_points?: number
   group_winner_points?: number
   stage_winner_points?: number
+  predictions_open?: PredictionsOpen
 }
 
 export interface TournamentUpdate extends Partial<TournamentCreate> {}


### PR DESCRIPTION
- Add predictions_open tournament setting to keep tournament/stage/group manually open after kick-off #31